### PR TITLE
WarScreen needs 15 participants otherwise it could crash and freeze, …

### DIFF
--- a/src/main/java/swcnoops/server/commands/guild/GuildWarStatus.java
+++ b/src/main/java/swcnoops/server/commands/guild/GuildWarStatus.java
@@ -6,14 +6,14 @@ import swcnoops.server.commands.guild.response.GuildWarStatusCommandResult;
 import swcnoops.server.datasource.War;
 import swcnoops.server.json.JsonParser;
 import swcnoops.server.model.BuffBase;
+import swcnoops.server.model.Participant;
 import swcnoops.server.model.SquadMemberWarData;
+import swcnoops.server.model.WarSquad;
 import swcnoops.server.session.GuildSession;
 import swcnoops.server.session.PlayerSession;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 public class GuildWarStatus extends AbstractCommandAction<GuildWarStatus, GuildWarStatusCommandResult> {
 
@@ -33,6 +33,7 @@ public class GuildWarStatus extends AbstractCommandAction<GuildWarStatus, GuildW
         GuildWarStatusCommandResult guildWarStatusResponse =
                 new GuildWarStatusCommandResult(guildSession);
         guildWarStatusResponse.inititalise(war, warParticipants1, warParticipants2, time);
+        patchWarParticipants(guildWarStatusResponse);
 
         // buff bases can not be null otherwise client crashes
         guildWarStatusResponse.buffBases = new ArrayList<>();
@@ -48,6 +49,30 @@ public class GuildWarStatus extends AbstractCommandAction<GuildWarStatus, GuildW
 
         guildWarStatusResponse.actionsStarted = false;
         return guildWarStatusResponse;
+    }
+
+    private void patchWarParticipants(GuildWarStatusCommandResult guildWarStatusResponse) {
+        patchParticipantsWithBots(guildWarStatusResponse.guild);
+        patchParticipantsWithBots(guildWarStatusResponse.rival);
+    }
+
+    private void patchParticipantsWithBots(WarSquad guild) {
+        if (guild.participants.size() != 15) {
+            for (int i = guild.participants.size(); i < 15; i++) {
+                guild.participants.add(createBotParticipant(guild.guildId, i));
+            }
+        }
+    }
+
+    private Participant createBotParticipant(String guildId, int i) {
+        Participant participant = new Participant();
+        participant.score = 0;
+        participant.level = 3;
+        participant.id = guildId + "_BOT" + i;
+        participant.name = "BOT" + i;
+        participant.victoryPoints = 0;
+        participant.turns = 0;
+        return participant;
     }
 
     private BuffBase create(String warBuff) {

--- a/src/main/java/swcnoops/server/commands/player/PlayerBattleReplayGet.java
+++ b/src/main/java/swcnoops/server/commands/player/PlayerBattleReplayGet.java
@@ -6,6 +6,7 @@ import swcnoops.server.commands.player.response.PlayerBattleReplayGetResult;
 import swcnoops.server.datasource.WarBattle;
 import swcnoops.server.json.JsonParser;
 import swcnoops.server.model.*;
+import swcnoops.server.requests.ResponseHelper;
 
 public class PlayerBattleReplayGet extends AbstractCommandAction<PlayerBattleReplayGet, PlayerBattleReplayGetResult> {
     private String battleId;
@@ -13,7 +14,10 @@ public class PlayerBattleReplayGet extends AbstractCommandAction<PlayerBattleRep
 
     @Override
     protected PlayerBattleReplayGetResult execute(PlayerBattleReplayGet arguments, long time) throws Exception {
+        // TODO - support PvP replays, only war for now
         WarBattle warBattle = ServiceFactory.instance().getPlayerDatasource().getWarBattle(arguments.getBattleId());
+        if (warBattle == null)
+            return new PlayerBattleReplayGetResult(ResponseHelper.REPLAY_DATA_NOT_FOUND);
 
         BattleReplay battleReplay = warBattle.getBattleReplay();
         stopClientCrash(battleReplay);

--- a/src/main/java/swcnoops/server/commands/player/response/PlayerBattleReplayGetResult.java
+++ b/src/main/java/swcnoops/server/commands/player/response/PlayerBattleReplayGetResult.java
@@ -2,11 +2,23 @@ package swcnoops.server.commands.player.response;
 
 import swcnoops.server.model.BattleReplay;
 import swcnoops.server.requests.AbstractCommandResult;
+import swcnoops.server.requests.ResponseHelper;
 
 public class PlayerBattleReplayGetResult extends AbstractCommandResult {
     private BattleReplay battleReplay;
+    private int statusCode;
     public PlayerBattleReplayGetResult(BattleReplay battleReplay) {
+        this(ResponseHelper.RECEIPT_STATUS_COMPLETE);
         this.battleReplay = battleReplay;
+    }
+
+    public PlayerBattleReplayGetResult(int replayDataNotFound) {
+        this.statusCode = replayDataNotFound;
+    }
+
+    @Override
+    public Integer getStatus() {
+        return this.statusCode;
     }
 
     @Override

--- a/src/main/java/swcnoops/server/game/GameDataManagerImpl.java
+++ b/src/main/java/swcnoops/server/game/GameDataManagerImpl.java
@@ -62,9 +62,9 @@ public class GameDataManagerImpl implements GameDataManager {
             troopList.add(b);
         });
 
-        // map used to group troops by unit size for SC populating, does not include special attack
+        // map used to group troops by unit size for SC populating, does not include special attacks or champions
         this.lowestLevelTroopByUnitId.forEach((a,b) -> {
-            if (!b.isSpecialAttack()) {
+            if (!b.isSpecialAttack() && !(b.getType() == TroopType.champion)) {
                 Map<Integer, List<TroopData>> troopBySizeMap = this.troopSizeMapByFaction.get(b.getFaction());
                 if (troopBySizeMap == null) {
                     troopBySizeMap = new HashMap<>();


### PR DESCRIPTION
…adding BOTs to make up the numbers.

Fix for random SC to not include champions as that prevents the SC from being sniped as the client freezes due to trying to initialise the champion.
Return not found replay when for PvP to stop it crashing on PvP replay.